### PR TITLE
Fix for LEDs to turn on when powered on

### DIFF
--- a/src/robot.c
+++ b/src/robot.c
@@ -339,10 +339,13 @@ void adc_shutdown(){
 }
 
 void turn_on_leds(){
-    // Set GPIO to PWM with frequency 1kHz and 50% duty cycle
     gpio_set_function(LED_EN_PIN, GPIO_FUNC_PWM);
-    // level between 0 and 255 inclusive
-    pwm_set_gpio_level(LED_EN_PIN, 255);
+
+    uint slice = pwm_gpio_to_slice_num(LED_EN_PIN);
+
+    pwm_set_wrap(slice, 255);                    // 8-bit PWM range (0–255)
+    pwm_set_gpio_level(LED_EN_PIN, 128);         // ~50% duty cycle
+    pwm_set_enabled(slice, true);
 }
 
 //---------------------------------------------------------------------


### PR DESCRIPTION
Fix for https://github.com/oist/smartphone-robot-firmware/issues/12

Previously, the turn_on_leds() function set the PWM level using pwm_set_gpio_level(LED_EN_PIN, 255) without configuring the PWM wrap. This caused confusion because the level argument is relative to the current wrap value (default 65535), not a fixed 0–255 range.

The misunderstanding was treating the level as an 8-bit value without adjusting the wrap, resulting in an effectively near 0% duty cycle.

This update explicitly sets the PWM wrap to 255, establishing a clear 8-bit range for duty cycle. The level is then set to 128 for approximately 50% duty cycle. The PWM slice is enabled explicitly, ensuring the PWM signal runs as expected.

This change simplifies the PWM setup and makes duty cycle values intuitive, avoiding reliance on undocumented defaults or hardcoded constants.